### PR TITLE
Fix Naev VERSION file and bump luajit.

### DIFF
--- a/org.naev.Naev.yaml
+++ b/org.naev.Naev.yaml
@@ -62,7 +62,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/LuaJIT/LuaJIT.git
-        commit: 6c4826f12c4d33b8b978004bc681eb1eef2be977
+        commit: 564147f518af5a5d8985d9e09fc3a768231f4e75
 
   - shared-modules/physfs/physfs.json
 

--- a/org.naev.Naev.yaml
+++ b/org.naev.Naev.yaml
@@ -37,6 +37,21 @@ modules:
         url: https://github.com/adah1972/libunibreak/releases/download/libunibreak_5_0/libunibreak-5.0.tar.gz
         sha256: 58f2fe4f9d9fc8277eb324075ba603479fa847a99a4b134ccb305ca42adf7158
 
+  - name: enet
+    buildsystem: autotools
+    sources:
+      - type: git
+        url: https://github.com/lsalzman/enet.git
+        tag: v1.3.17
+        commit: e0e7045b7e056b454b5093cb34df49dc4cee0bee
+        x-checker-data:
+          type: git
+          tag-pattern: ^v([\d.]+)$
+      - type: script
+        dest-filename: autogen.sh
+        commands:
+          - autoreconf -ifv
+
   - name: luajit
     no-autogen: true
     make-install-args:

--- a/org.naev.Naev.yaml
+++ b/org.naev.Naev.yaml
@@ -21,6 +21,10 @@ modules:
       - type: file
         url: https://files.pythonhosted.org/packages/36/2b/61d51a2c4f25ef062ae3f74576b01638bebad5e045f747ff12643df63844/PyYAML-6.0.tar.gz
         sha256: 68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2
+        x-checker-data:
+          type: pypi
+          name: PyYAML
+          packagetype: sdist
 
   - name: libunibreak
     no-autogen: false

--- a/org.naev.Naev.yaml
+++ b/org.naev.Naev.yaml
@@ -136,12 +136,13 @@ modules:
       - -Ddocs_c=disabled
       - -Ddocs_lua=disabled
     sources:
-      - type: git
-        url: https://github.com/naev/naev.git
-        tag: v0.10.1
-        commit: be64b408383f9c1507f0657a15d4aa7a3f34084b
+      - type: archive
+        url: https://github.com/naev/naev/releases/download/v0.10.1/naev-0.10.1-source.tar.xz
+        sha256: 4a1013eebb50f728fc601bdd833b0b2870333c3b3e5a816eeba921d95bec6f15
         x-checker-data:
-          type: git
-          tag-pattern: ^v([\d.]+)$
+          type: anitya
+          project-id: 5571
+          stable-only: true
+          url-template: https://github.com/naev/naev/releases/download/v$version/naev-$version-source.tar.xz
       - type: patch
         path: metainfo.patch

--- a/org.naev.Naev.yaml
+++ b/org.naev.Naev.yaml
@@ -138,7 +138,7 @@ modules:
     sources:
       - type: archive
         url: https://github.com/naev/naev/releases/download/v0.10.1/naev-0.10.1-source.tar.xz
-        sha256: 4a1013eebb50f728fc601bdd833b0b2870333c3b3e5a816eeba921d95bec6f15
+        sha256: 9efd2ca54179741c793dbe690aacb2bf79d4accbf4c7632d7713e0ea4d3d449f
         x-checker-data:
           type: anitya
           project-id: 5571

--- a/org.naev.Naev.yaml
+++ b/org.naev.Naev.yaml
@@ -93,11 +93,6 @@ modules:
       - type: archive
         url: https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/v5.13.0.tar.gz
         sha256: 59c6ca2959623f0c69226cf9afb9a018d12a37fab3a8869db5f6d7f83b6b147d
-        x-checker-data:
-          type: anitya
-          project-id: 4908
-          stable-only: true
-          url-template: https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/v$version.tar.gz
       - type: patch
         path: suitesparse-reduce-build.patch
 

--- a/org.naev.Naev.yaml
+++ b/org.naev.Naev.yaml
@@ -138,10 +138,10 @@ modules:
     sources:
       - type: git
         url: https://github.com/naev/naev.git
-        tag: v0.9.4
-        commit: c8910b40b3840d1f04150474da151380bc82d322
+        tag: v0.10.1
+        commit: be64b408383f9c1507f0657a15d4aa7a3f34084b
         x-checker-data:
           type: git
-          tag-pattern: ^v([0-9.]+)$
+          tag-pattern: ^v([\d.]+)$
       - type: patch
         path: metainfo.patch


### PR DESCRIPTION
Fix Naev VERSION file and bump luajit.

The VERSION file is built incorrectly if built directly from git. This change will fix the displayed version and avoid issues with updating saves.