### PR TITLE
FreeDesktop 25.08, Metainfo, PhysFS and GLPK updates

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,0 @@
-{
-    "automerge-flathubbot-prs": true
-  }

--- a/local-build.sh
+++ b/local-build.sh
@@ -27,8 +27,8 @@ check_command "flatpak-builder"
 
 # Define required Flatpak packages
 REQUIRED_FLATPAK_PACKAGES=(
-    "org.freedesktop.Platform//24.08"
-    "org.freedesktop.Sdk//24.08"
+    "org.freedesktop.Platform//25.08"
+    "org.freedesktop.Sdk//25.08"
 )
 
 # Function to check if a Flatpak package is installed

--- a/metainfo.patch
+++ b/metainfo.patch
@@ -1,10 +1,186 @@
---- a/org.naev.Naev.metainfo.xml	2024-12-23 14:37:36.417070934 -0500
-+++ b/org.naev.Naev.metainfo.xml	2024-12-23 14:38:06.115708718 -0500
-@@ -9,7 +9,6 @@
+--- naev-0.12.6-a/org.naev.Naev.metainfo.xml	2025-07-08 15:58:11.000000000 -0400
++++ naev-0.12.6-b/org.naev.Naev.metainfo.xml	2025-09-26 09:31:11.596900101 -0400
+@@ -1,4 +1,4 @@
+-<?xml version="1.0" encoding="UTF-8"?>
++<!-- Copyright 2025 Naev DevTeam -->
+ <component type="desktop-application">
+   <id>org.naev.Naev</id>
+ 
+@@ -9,9 +9,12 @@
    <developer id="org.naev">
     <name>Naev DevTeam</name>
    </developer>
 -  <icon type="stock">org.naev.Naev</icon>
    <url type="homepage">https://naev.org</url>
-   <url type="bugtracker">https://github.com/naev/naev/issues</url>
+-  <url type="bugtracker">https://github.com/naev/naev/issues</url>
++  <url type="bugtracker">https://codeberg.org/naev/naev/issues</url>
++  <url type="contribute">https://codeberg.org/naev/naev</url>
++  <url type="contact">https://naev.org/contact/</url>
++  <url type="translate">https://hosted.weblate.org/projects/naev/</url>
++  <url type="vcs-browser">https://codeberg.org/naev/naev</url>
    <metadata_license>CC0-1.0</metadata_license>
+   <project_license>GPL-3.0-or-later</project_license>
+   <update_contact>bobbens_AT_gmail.com</update_contact>
+@@ -22,6 +25,11 @@
+     <!--<control>gamepad</control>-->
+   </recommends>
+ 
++  <branding>
++    <color type="primary" scheme_preference="light">#62a0ea</color>
++    <color type="primary" scheme_preference="dark">#1c71d8</color>
++  </branding>
++
+   <description>
+     <p>
+       Naev is a 2D space trading and combat game, taking inspiration from the Escape Velocity series, among others.
+@@ -46,113 +54,115 @@
+   <categories>
+     <category>Game</category>
+     <category>AdventureGame</category>
++    <category>ActionGame</category>
++    <category>RolePlaying</category>
+   </categories>
+ 
+   <releases>
+     <release version="0.12.6" type="stable" date="2025-07-09">
+-      <url>https://naev.org/blarg/2025-07-09_0.12.6/</url>
++      <url type="details">https://naev.org/blarg/2025-07-09_0.12.6/</url>
+     </release>
+     <release version="0.12.5" type="stable" date="2025-05-23">
+-      <url>https://naev.org/blarg/2025-05-23_0.12.5/</url>
++      <url type="details">https://naev.org/blarg/2025-05-23_0.12.5/</url>
+     </release>
+     <release version="0.12.4" type="stable" date="2025-04-06">
+-      <url>https://naev.org/blarg/2025-04-06_0.12.4/</url>
++      <url type="details">https://naev.org/blarg/2025-04-06_0.12.4/</url>
+     </release>
+     <release version="0.12.3" type="stable" date="2025-02-01">
+-      <url>https://naev.org/blarg/2025-02-01_0.12.3/</url>
++      <url type="details">https://naev.org/blarg/2025-02-01_0.12.3/</url>
+     </release>
+     <release version="0.12.2" type="stable" date="2025-01-09">
+-      <url>https://naev.org/blarg/2025-01-09_0.12.2/</url>
++      <url type="details">https://naev.org/blarg/2025-01-09_0.12.2/</url>
+     </release>
+     <release version="0.12.1" type="stable" date="2024-12-27">
+-      <url>https://naev.org/blarg/2024-12-27_0.12.1/</url>
++      <url type="details">https://naev.org/blarg/2024-12-27_0.12.1/</url>
+     </release>
+     <release version="0.12.0" type="stable" date="2024-12-23">
+-      <url>https://naev.org/blarg/2024-12-23_0.12.0/</url>
++      <url type="details">https://naev.org/blarg/2024-12-23_0.12.0/</url>
+     </release>
+     <release version="0.11.5" type="stable" date="2024-06-13">
+-      <url>https://naev.org/blarg/2024-06-13_0.11.5/</url>
++      <url type="details">https://naev.org/blarg/2024-06-13_0.11.5/</url>
+     </release>
+     <release version="0.11.4" type="stable" date="2024-03-09">
+-      <url>https://naev.org/blarg/2024-03-09_0.11.4/</url>
++      <url type="details">https://naev.org/blarg/2024-03-09_0.11.4/</url>
+     </release>
+     <release version="0.11.3" type="stable" date="2024-01-25">
+-      <url>https://naev.org/blarg/2024-01-25_0.11.3/</url>
++      <url type="details">https://naev.org/blarg/2024-01-25_0.11.3/</url>
+     </release>
+     <release version="0.11.2" type="stable" date="2024-01-15">
+-      <url>https://naev.org/blarg/2024-01-15_0.11.2/</url>
++      <url type="details">https://naev.org/blarg/2024-01-15_0.11.2/</url>
+     </release>
+     <release version="0.11.1" type="stable" date="2024-01-14">
+-      <url>https://naev.org/blarg/2024-01-14_0.11.1/</url>
++      <url type="details">https://naev.org/blarg/2024-01-14_0.11.1/</url>
+     </release>
+     <release version="0.11.0" type="stable" date="2023-12-23">
+-      <url>https://naev.org/blarg/2023-12-23_0.11.0/</url>
++      <url type="details">https://naev.org/blarg/2023-12-23_0.11.0/</url>
+     </release>
+     <release version="0.10.6" type="stable" date="2023-07-07">
+-      <url>https://naev.org/blarg/2023-07-07_0.10.6/</url>
++      <url type="details">https://naev.org/blarg/2023-07-07_0.10.6/</url>
+     </release>
+     <release version="0.10.5" type="stable" date="2023-04-23">
+-      <url>https://naev.org/blarg/2023-04-23_0.10.5/</url>
++      <url type="details">https://naev.org/blarg/2023-04-23_0.10.5/</url>
+     </release>
+     <release version="0.10.4" type="stable" date="2023-02-04">
+-      <url>https://naev.org/blarg/2023-02-04_0.10.4/</url>
++      <url type="details">https://naev.org/blarg/2023-02-04_0.10.4/</url>
+     </release>
+     <release version="0.10.3" type="stable" date="2023-01-17">
+-      <url>https://naev.org/blarg/2023-01-17_0.10.3/</url>
++      <url type="details">https://naev.org/blarg/2023-01-17_0.10.3/</url>
+     </release>
+     <release version="0.10.2" type="stable" date="2023-01-12">
+-      <url>https://naev.org/blarg/2023-01-12_0.10.2/</url>
++      <url type="details">https://naev.org/blarg/2023-01-12_0.10.2/</url>
+     </release>
+     <release version="0.10.1" type="stable" date="2022-12-29">
+-      <url>https://naev.org/blarg/2022-12-29_0.10.1/</url>
++      <url type="details">https://naev.org/blarg/2022-12-29_0.10.1/</url>
+     </release>
+     <release version="0.10.0" type="stable" date="2022-12-23">
+-      <url>https://naev.org/blarg/2022-12-23_0.10.0/</url>
++      <url type="details">https://naev.org/blarg/2022-12-23_0.10.0/</url>
+     </release>
+     <release version="0.9.4" type="stable" date="2022-07-20">
+-      <url>https://naev.org/blarg/2022-07-20_0.9.4/</url>
++      <url type="details">https://naev.org/blarg/2022-07-20_0.9.4/</url>
+     </release>
+     <release version="0.9.3" type="stable" date="2022-04-02">
+-      <url>https://naev.org/blarg/2022-04-03_0.9.3/</url>
++      <url type="details">https://naev.org/blarg/2022-04-03_0.9.3/</url>
+     </release>
+     <release version="0.9.2" type="stable" date="2022-01-20">
+-      <url>https://naev.org/blarg/2022-01-20_0.9.2</url>
++      <url type="details">https://naev.org/blarg/2022-01-20_0.9.2</url>
+     </release>
+     <release version="0.9.1" type="stable" date="2022-01-02">
+-      <url>https://naev.org/blarg/2022-01-02_0.9.1</url>
++      <url type="details">https://naev.org/blarg/2022-01-02_0.9.1</url>
+     </release>
+     <release version="0.9.0" type="stable" date="2021-12-23">
+-      <url>https://naev.org/blarg/2021-12-23_0.9.0</url>
++      <url type="details">https://naev.org/blarg/2021-12-23_0.9.0</url>
+     </release>
+     <release version="0.8.2" type="stable" date="2021-02-12">
+-      <url>https://naev.org/blarg/2021-02-12_0.8.2</url>
++      <url type="details">https://naev.org/blarg/2021-02-12_0.8.2</url>
+     </release>
+     <release version="0.8.1" type="stable" date="2021-01-09">
+-      <url>https://naev.org/blarg/2021-01-09_0.8.1</url>
++      <url type="details">https://naev.org/blarg/2021-01-09_0.8.1</url>
+     </release>
+     <release version="0.8.0" type="stable" date="2020-12-17">
+-      <url>https://naev.org/blarg/2020-12-17_0.8.0</url>
++      <url type="details">https://naev.org/blarg/2020-12-17_0.8.0</url>
+     </release>
+     <release version="0.7.0" type="stable" date="2017-07-08">
+-      <url>https://naev.org/blarg/2017-07-08_0.7.0</url>
++      <url type="details">https://naev.org/blarg/2017-07-08_0.7.0</url>
+     </release>
+     <release version="0.6.1" type="stable" date="2015-11-15">
+-      <url>https://naev.org/blarg/2015-11-15_0.6.1</url>
++      <url type="details">https://naev.org/blarg/2015-11-15_0.6.1</url>
+     </release>
+     <release version="0.6.0" type="stable" date="2015-03-17">
+-      <url>https://naev.org/blarg/2015-03-17_0.6.0</url>
++      <url type="details">https://naev.org/blarg/2015-03-17_0.6.0</url>
+     </release>
+     <release version="0.5.3" type="stable" date="2012-04-15">
+-      <url>https://naev.org/blarg/2012-04-15_0.5.3</url>
++      <url type="details">https://naev.org/blarg/2012-04-15_0.5.3</url>
+     </release>
+     <release version="0.5.2" type="stable" date="2012-03-25">
+-      <url>https://naev.org/blarg/2012-03-25_0.5.2</url>
++      <url type="details">https://naev.org/blarg/2012-03-25_0.5.2</url>
+     </release>
+     <release version="0.5.1" type="stable" date="2012-03-01">
+-      <url>https://naev.org/blarg/2012-03-01_0.5.1</url>
++      <url type="details">https://naev.org/blarg/2012-03-01_0.5.1</url>
+     </release>
+     <release version="0.5.0" type="stable" date="2011-06-03">
+-      <url>https://naev.org/blarg/2011-06-03_0.5.0</url>
++      <url type="details">https://naev.org/blarg/2011-06-03_0.5.0</url>
+     </release>
+   </releases>
+ 

--- a/minisat-c23-fix.patch
+++ b/minisat-c23-fix.patch
@@ -1,0 +1,16 @@
+--- glpk-5.0-a/src/minisat/minisat.h	2020-12-16 04:00:00.000000000 -0500
++++ glpk-5.0-b/src/minisat/minisat.h	2025-09-26 10:27:24.609205881 -0400
+@@ -34,7 +34,13 @@
+ /*====================================================================*/
+ /* Simple types: */
+ 
++#if __STDC_VERSION__ < 199901L  /* before C99, no stdbool */
+ typedef int bool;
++#define true 1
++#define false 0
++#else
++#include <stdbool.h>
++#endif
+ 
+ #define true  1
+ #define false 0

--- a/org.naev.Naev.yaml
+++ b/org.naev.Naev.yaml
@@ -163,7 +163,7 @@ modules:
           version-query: .tag_name
           url-query: .assets[] | select(.name|endswith(".tar.gz")) | .browser_download_url
 
-  - shared-modules/physfs/physfs.json
+  - physfs.json
 
   - name: python3-pyyaml
     buildsystem: simple

--- a/org.naev.Naev.yaml
+++ b/org.naev.Naev.yaml
@@ -219,7 +219,7 @@ modules:
         sha512: 4d28e9caa26e4c6328b33f17e7c101bc80c6f30540f8d148e7441a9193a3a1a7ee647d501acde7b72b60a9e60ef66774363fdeacefa7c2b7522e278ed44017d2
         x-checker-data:
           type: json
-          url: https://api.github.com/repos/naev/naev/releases/latest
+          url: https://codeberg.org/api/v1/repos/naev/naev/releases/latest
           version-query: .tag_name
           url-query: .assets[] | select(.name|endswith("-source.tar.xz")) | .browser_download_url
       - type: patch

--- a/org.naev.Naev.yaml
+++ b/org.naev.Naev.yaml
@@ -215,7 +215,7 @@ modules:
       - /lib/debug
     sources:
       - type: archive
-        url: https://github.com/naev/naev/releases/download/v0.12.6/naev-0.12.6-source.tar.xz
+        url: https://codeberg.org/naev/naev/releases/download/v0.12.6/naev-0.12.6-source.tar.xz
         sha512: 4d28e9caa26e4c6328b33f17e7c101bc80c6f30540f8d148e7441a9193a3a1a7ee647d501acde7b72b60a9e60ef66774363fdeacefa7c2b7522e278ed44017d2
         x-checker-data:
           type: json

--- a/org.naev.Naev.yaml
+++ b/org.naev.Naev.yaml
@@ -74,13 +74,13 @@ modules:
       - /share/man
     sources:
       - type: archive
-        url: https://ftp.gnu.org/gnu/glpk/glpk-5.0.tar.gz
+        url: https://ftpmirror.gnu.org/gnu/glpk/glpk-5.0.tar.gz
         sha512: 4e92195fa058c707146f2690f3a38b46c33add948c852f67659ca005a6aa980bbf97be96528b0f8391690facb880ac2126cd60198c6c175e7f3f06cca7e29f9d
         x-checker-data:
           type: anitya
           project-id: 1183
           stable-only: true
-          url-template: https://ftp.gnu.org/gnu/glpk/glpk-$version.tar.gz
+          url-template: https://ftpmirror.gnu.org/gnu/glpk/glpk-$version.tar.gz
 
   - name: libunibreak
     no-autogen: false

--- a/org.naev.Naev.yaml
+++ b/org.naev.Naev.yaml
@@ -215,8 +215,8 @@ modules:
       - /lib/debug
     sources:
       - type: archive
-        url: https://github.com/naev/naev/releases/download/v0.12.4/naev-0.12.4-source.tar.xz
-        sha512: 4eaf44a983e218e1c3b8d730d768cfd659fa90efb140b8cbf18d743276eba2e3af71dc66ab47dd369e9eedabcafc109b79de4f97c93c8d38306c74d59a0340ae
+        url: https://github.com/naev/naev/releases/download/v0.12.5/naev-0.12.5-source.tar.xz
+        sha512: 1f30a674c8fd32a1d52b62b60ac032865993a513284b76417f00f00c30747475af914fb721410c8e378b154e6e4475414d5db3ea8f543a2eea2b3d37d83fecf0
         x-checker-data:
           type: json
           url: https://api.github.com/repos/naev/naev/releases/latest

--- a/org.naev.Naev.yaml
+++ b/org.naev.Naev.yaml
@@ -1,6 +1,6 @@
 id: org.naev.Naev
 runtime: org.freedesktop.Platform
-runtime-version: '24.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 command: naev
 rename-appdata-file: org.naev.Naev.metainfo.xml
@@ -178,6 +178,8 @@ modules:
           type: pypi
           name: PyYAML
           packagetype: sdist
+
+  - shared-modules/SDL2/SDL2_image.json
 
   - name: suitesparse
     buildsystem: cmake-ninja

--- a/org.naev.Naev.yaml
+++ b/org.naev.Naev.yaml
@@ -81,6 +81,8 @@ modules:
           project-id: 1183
           stable-only: true
           url-template: https://ftpmirror.gnu.org/gnu/glpk/glpk-$version.tar.gz
+      - type: patch
+        path: minisat-c23-fix.patch
 
   - name: libunibreak
     no-autogen: false

--- a/org.naev.Naev.yaml
+++ b/org.naev.Naev.yaml
@@ -153,8 +153,8 @@ modules:
       - /share/man
     sources:
       - type: archive
-        url: https://github.com/OpenMathLib/OpenBLAS/releases/download/v0.3.29/OpenBLAS-0.3.29.tar.gz
-        sha512: 046316b4297460bffca09c890ecad17ea39d8b3db92ff445d03b547dd551663d37e40f38bce8ae11e2994374ff01e622b408da27aa8e40f4140185ee8f001a60
+        url: https://github.com/OpenMathLib/OpenBLAS/releases/download/v0.3.30/OpenBLAS-0.3.30.tar.gz
+        sha512: c726ced2d3e6ebd3ddcd0b13c255bb43fae8c12d2aec15e9ef992b0bc7099996c02cd284ccaaa7b5fac3f23f280b098063dd60f521d97a68dc183ab192fcccdb
         x-checker-data:
           type: json
           url: https://api.github.com/repos/OpenMathLib/OpenBLAS/releases/latest
@@ -215,8 +215,8 @@ modules:
       - /lib/debug
     sources:
       - type: archive
-        url: https://github.com/naev/naev/releases/download/v0.12.5/naev-0.12.5-source.tar.xz
-        sha512: 1f30a674c8fd32a1d52b62b60ac032865993a513284b76417f00f00c30747475af914fb721410c8e378b154e6e4475414d5db3ea8f543a2eea2b3d37d83fecf0
+        url: https://github.com/naev/naev/releases/download/v0.12.6/naev-0.12.6-source.tar.xz
+        sha512: 4d28e9caa26e4c6328b33f17e7c101bc80c6f30540f8d148e7441a9193a3a1a7ee647d501acde7b72b60a9e60ef66774363fdeacefa7c2b7522e278ed44017d2
         x-checker-data:
           type: json
           url: https://api.github.com/repos/naev/naev/releases/latest

--- a/physfs.json
+++ b/physfs.json
@@ -1,0 +1,26 @@
+{
+  "name": "PhysicsFS",
+  "buildsystem": "cmake-ninja",
+  "config-opts": [
+    "-DPHYSFS_BUILD_TEST=OFF",
+    "-DPHYSFS_BUILD_STATIC=OFF",
+    "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+  ],
+  "cleanup": [
+    "/include",
+    "/lib/pkgconfig",
+    "/bin"
+  ],
+  "sources": [
+    {
+      "type": "git",
+      "url": "https://github.com/icculus/physfs.git",
+      "tag": "release-3.2.0",
+      "commit": "eb3383b532c5f74bfeb42ec306ba2cf80eed988c",
+      "x-checker-data": {
+        "type": "git",
+        "tag-pattern": "^release-([0-9.]+)$"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Updates to the FreeDesktop 25.08 runtime, patches the metainfo to include upstream source changes, updates PhysFS to 3.2.0 and fixes build and mirror issues with GLPK.

Currently the Flatpak that is built on Flathub infra crashes on launch.

I have updated the physfs module locally, and have a PR posted upstream to get it into shared-modules. Using ftpmirror.gnu.org will avoid hammering gnu.org with downloads.